### PR TITLE
Fix undo/redo stack update

### DIFF
--- a/public/canvas.js
+++ b/public/canvas.js
@@ -50,8 +50,12 @@ canvas.addEventListener("mouseup", (e) => {
     mouseDown = false;
 
     let url = canvas.toDataURL();
+    // remove states ahead of the current track position before pushing
+    if (track < undoRedoTracker.length - 1) {
+        undoRedoTracker.splice(track + 1);
+    }
     undoRedoTracker.push(url);
-    track = undoRedoTracker.length-1;
+    track = undoRedoTracker.length - 1;
 })
 
 undo.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- remove future states when writing new history entries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a104594f48333b767811fdba76738