### PR TITLE
Add multi-board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ As of now, there is also similar project on the repo by the name of Excalidraw o
 
 #Steps to run the project on the local machine 
 
-change the following line found in the index.html document to the backend server address for your local machine it might look something like http://localhost:3000 which will enable the socket client module to make connect with the socket server module on your local machine.
-
-let socket = io.connect("https://openboard-clone-wlv5.onrender.com");
+run `npm install` and `npm start`.
+Open http://localhost:3000 which will create a new board and redirect you to a
+unique URL. Share this URL with other users so that they join the same board.
+The client automatically connects to the correct board based on the URL so no
+code changes are required.
 
 
 Akshay Patel

--- a/app.js
+++ b/app.js
@@ -1,9 +1,24 @@
 const express = require("express"); // Access
 const socket = require("socket.io");
+const path = require("path");
+const { v4: uuidv4 } = require("uuid");
 
 const app = express(); //Initialized and server ready
 
 app.use(express.static("public"));
+
+app.get("/create", (req, res) => {
+    const id = uuidv4();
+    res.redirect(`/${id}`);
+});
+
+app.get("/", (req, res) => {
+    res.redirect("/create");
+});
+
+app.get("/:board", (req, res) => {
+    res.sendFile(path.join(__dirname, "public", "index.html"));
+});
 
 
 
@@ -15,18 +30,22 @@ let server = app.listen(port, () => {
 let io = socket(server);
 
 io.on("connection", (socket) => {
+    const boardId = socket.handshake.query.boardId;
+    if (boardId) {
+        socket.join(boardId);
+    }
     console.log("Made socket connection");
     // Received data
     socket.on("beginPath", (data) => {
         // data -> data from frontend
-        // Now transfer data to all connected computers
-        io.sockets.emit("beginPath", data);
+        // Now transfer data to all connected clients in the room
+        if (boardId) io.to(boardId).emit("beginPath", data);
     })
     socket.on("drawStroke", (data) => {
-        io.sockets.emit("drawStroke", data);
+        if (boardId) io.to(boardId).emit("drawStroke", data);
     })
     socket.on("redoUndo", (data) => {
-        io.sockets.emit("redoUndo", data);
+        if (boardId) io.to(boardId).emit("redoUndo", data);
     })
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.1",
-        "socket.io": "^4.2.0"
+        "socket.io": "^4.2.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "jest": "^30.0.2",
@@ -5942,6 +5943,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10322,6 +10332,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
-    "socket.io": "^4.2.0"
+    "socket.io": "^4.2.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "nodemon": "^2.0.13",
     "jest": "^30.0.2",
+    "nodemon": "^2.0.13",
     "socket.io-client": "^4.2.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,8 @@
     <canvas></canvas>
     <script src="https://cdn.socket.io/4.2.0/socket.io.min.js" integrity="sha384-PiBR5S00EtOj2Lto9Uu81cmoyZqR57XcOna1oAuVuIEjzj0wpqDVfD0JA9eXlRsj" crossorigin="anonymous"></script>
     <script>
-        let socket = io.connect("https://openboard-clone-wlv5.onrender.com");
+        const boardId = window.location.pathname.split("/")[1];
+        const socket = io({ query: { boardId } });
     </script>
     <script src="./tools.js"></script>
     <script src="./canvas.js"></script>

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -13,16 +13,16 @@ afterAll(done => {
   server.close(done);
 });
 
-function connect() {
+function connect(boardId = 'test') {
   return new Promise(resolve => {
-    const client = ioClient(url);
+    const client = ioClient(url, { query: { boardId } });
     client.on('connect', () => resolve(client));
   });
 }
 
-test('broadcasts drawing events to all clients', async () => {
-  const client1 = await connect();
-  const client2 = await connect();
+test('broadcasts drawing events to all clients in the same board', async () => {
+  const client1 = await connect('board1');
+  const client2 = await connect('board1');
 
   const beginData = { x: 0, y: 0 };
   const drawData = { x: 1, y: 1 };
@@ -42,4 +42,26 @@ test('broadcasts drawing events to all clients', async () => {
 
   client1.disconnect();
   client2.disconnect();
+});
+
+test('does not broadcast events across boards', async () => {
+  const a1 = await connect('boardA');
+  const a2 = await connect('boardA');
+  const b1 = await connect('boardB');
+
+  const waitPromise = new Promise(resolve => {
+    const timer = setTimeout(() => resolve('timeout'), 100);
+    b1.once('beginPath', () => {
+      clearTimeout(timer);
+      resolve('received');
+    });
+  });
+
+  a1.emit('beginPath', { x: 0, y: 0 });
+
+  await expect(waitPromise).resolves.toBe('timeout');
+
+  a1.disconnect();
+  a2.disconnect();
+  b1.disconnect();
 });


### PR DESCRIPTION
## Summary
- handle dynamic board IDs and redirect `/` to a new board
- join socket.io rooms based on board ID
- update client to pass board ID when connecting
- update tests for multiple boards
- document new usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a14af5ca08333b80c5e0aada8c3c1